### PR TITLE
Changing the method for Time.strptime Time.new helper.rb in class

### DIFF
--- a/lib/ruby_danfe/helper.rb
+++ b/lib/ruby_danfe/helper.rb
@@ -47,7 +47,7 @@ module RubyDanfe
       formated_time = ""
 
       if not string.empty?
-        time = Time.strptime(string, "%H:%M:%S")
+        time = Time.new(string)
         formated_time = time.strftime("%H:%M:%S")
       end
 


### PR DESCRIPTION
When you try to use an xml that was not of such an error occurred warning that there was no method "strptime" in class "Time". So I changed the class "Helper" to solve this problem.