### PR TITLE
bug fix - invalid date quando o formato da data no xml é %d/%m/%Y

### DIFF
--- a/lib/ruby_danfe/helper.rb
+++ b/lib/ruby_danfe/helper.rb
@@ -25,7 +25,7 @@ module RubyDanfe
       formated_datetime = ""
 
       if not string.empty?
-        date = DateTime.strptime(string, "%Y-%m-%dT%H:%M:%S")
+        date = extract_date_time(string)
         formated_datetime = date.strftime("%d/%m/%Y %H:%M:%S")
       end
 
@@ -58,11 +58,21 @@ module RubyDanfe
       formated_time = ""
 
       if not string.empty?
-        date = DateTime.strptime(string, "%Y-%m-%dT%H:%M:%S")
+        date = extract_date_time(string)
         formated_time = date.strftime("%H:%M:%S")
       end
 
       formated_time
+    end
+
+    private
+
+    def self.extract_date_time(string)
+      begin
+        DateTime.strptime(string, "%Y-%m-%dT%H:%M:%S")
+      rescue ArgumentError
+        DateTime.strptime(string, "%d/%m/%Y %H:%M:%S")
+      end
     end
   end
 end

--- a/spec/lib/helper_spec.rb
+++ b/spec/lib/helper_spec.rb
@@ -2,9 +2,18 @@ require "spec_helper"
 
 describe RubyDanfe::Helper do
   describe ".format_datetime" do
-    it "returns a formated string" do
-      string = "2013-10-18T13:54:04"
-      expect(RubyDanfe::Helper.format_datetime(string)).to eq "18/10/2013 13:54:04"
+    context "when date format is %Y-%m-%d" do      
+      it "returns a formated string" do
+        string = "2013-10-18T13:54:04"
+        expect(RubyDanfe::Helper.format_datetime(string)).to eq "18/10/2013 13:54:04"
+      end
+    end
+
+    context "when date format is %d/%m/%Y" do      
+      it "returns a formated string" do
+        string = "25/02/2016  09:22:26"
+        expect(RubyDanfe::Helper.format_datetime(string)).to eq "25/02/2016 09:22:26"
+      end
     end
   end
 


### PR DESCRIPTION
Recebi uma NF-e com data '25/02/2016  09:22:26'. Fiz RubyDanfe::Helper. format_datetime funcionar com data no formato %d/%m/%Y.