### PR TITLE
Corrigida a emissão de Danfce com QR code e algumas refatorações

### DIFF
--- a/lib/ruby_danfe/dacte_generator.rb
+++ b/lib/ruby_danfe/dacte_generator.rb
@@ -42,13 +42,13 @@ module RubyDanfe
       fone = @xml['enderEmit/fone']
       unless fone.eql?('')
         if fone.size > 8
-          fone =  '(' + @xml['enderEmit/fone'][0,2] + ')' + @xml['enderEmit/fone'][2,4] + '-' + @xml['enderEmit/fone'][6,4]
+          fone =  '(' + @xml['enderEmit/fone'][0,2] + ') ' + @xml['enderEmit/fone'][2,5] + '-' + @xml['enderEmit/fone'][6,4]
         else
           fone = @xml['enderEmit/fone'][0,4] + '-' + @xml['enderEmit/fone'][4,4]
         end
       end
       @pdf.ibox 2.27, 7.67, 0.25, 1.20, '',
-        @xml['enderEmit/xLgr'] + ", " + @xml['enderEmit/nro'] + " " + @xml['enderEmit/xCpl'] + "\n" +
+        @xml['enderEmit/xLgr'] + ", " + @xml['enderEmit/nro'] + "\n" +
         @xml['enderEmit/xMun'] + " - " + @xml['enderEmit/UF'] + " " + @xml['enderEmit/xPais'] + "\n" +
         "Fone/Fax: " + fone,
         { :align => :center, :size => 8, :border => 0, :style => :bold }
@@ -375,7 +375,8 @@ module RubyDanfe
       x = 1.33
       @xml.collect('xmlns', 'infQ') { |det|
         if !det.css('cUnid').text.eql?('00')
-           @pdf.ibox 0.90, 3.50, x, 15.02, '', det.css('qCarga').text, { :size => 7, :style => :bold, :border => 0 }
+           desc = "#{det.css('qCarga').text} #{det.css('tpMed').text}"
+           @pdf.ibox 0.90, 3.50, x, 15.02, '', desc, { :size => 7, :style => :bold, :border => 0 }
            x = x + 3.50
         end
       }
@@ -474,28 +475,31 @@ module RubyDanfe
       @pdf.ibox 5.52, 1.00, 17.75, 19.13, 'SÉRIE', '', { :size => 7}
       @pdf.ibox 5.52, 2.00, 18.74, 19.13, 'Nº DOCUMENTO', '', { :size => 7}
       x = 0.25
+      y = 19.43
       @xml.collect('xmlns', 'infNF') { |det|
-        @pdf.ibox 5.52, 1.50, x, 19.43, '', det.css('mod').text, { :size => 7, :border => 0, :style => :bold }
+        x, y = 0.25, y + 0.25 if x == 20.75
+        @pdf.ibox 5.52, 1.50, x, y, '', det.css('mod').text, { :size => 7, :border => 0, :style => :bold }
         x = x + 1.75
-        @pdf.ibox 5.52, 2.25, x, 19.43, '', Helper.format_cnpj(@xml['rem/CNPJ']), { :size => 7, :border => 0, :style => :bold } if @xml['rem/CNPJ'] != ''
-        @pdf.ibox 5.52, 5.25, x, 19.43, '', @xml['rem/CPF'][0,3] + '.' + @xml['rem/CPF'][3,3] + '.' +@xml['rem/CPF'][6,3] + '-' + @xml['rem/CPF'][9,2], { :size => 7, :border => 0, :style => :bold } if @xml['rem/CPF'] != ''
+        @pdf.ibox 5.52, 2.25, x, y, '', Helper.format_cnpj(@xml['rem/CNPJ']), { :size => 7, :border => 0, :style => :bold } if @xml['rem/CNPJ'] != ''
+        @pdf.ibox 5.52, 5.25, x, y, '', @xml['rem/CPF'][0,3] + '.' + @xml['rem/CPF'][3,3] + '.' +@xml['rem/CPF'][6,3] + '-' + @xml['rem/CPF'][9,2], { :size => 7, :border => 0, :style => :bold } if @xml['rem/CPF'] != ''
         x = x + 5.50
-        @pdf.ibox 5.52, 0.75, x, 19.43, '', det.css('serie').text, { :size => 7, :border => 0, :style => :bold }
+        @pdf.ibox 5.52, 0.75, x, y, '', det.css('serie').text, { :size => 7, :border => 0, :style => :bold }
         x = x + 1.00
-        @pdf.ibox 5.52, 1.75, x, 19.43, '', det.css('nDoc').text, { :size => 7, :border => 0, :style => :bold }
+        @pdf.ibox 5.52, 1.75, x, y, '', det.css('nDoc').text, { :size => 7, :border => 0, :style => :bold }
         x = x + 2.00
       }
       # NFe
       @xml.collect('xmlns', 'infNFe') { |det|
         chave = det.css('chave').text
         unless chave.empty?
-          @pdf.ibox 5.52, 1.50, x, 19.43, '', 'NFe', { :size => 7, :border => 0, :style => :bold }
+          x, y = 0.25, y + 0.25 if x == 20.75
+          @pdf.ibox 5.52, 1.50, x, y, '', 'NFe', { :size => 7, :border => 0, :style => :bold }
           x = x + 1.75
-          @pdf.ibox 5.52, 5.25, x, 19.43, '', chave, { :size => 6, :border => 0, :style => :bold }
+          @pdf.ibox 5.52, 5.25, x, y, '', chave, { :size => 6, :border => 0, :style => :bold }
           x = x + 5.50
-          @pdf.ibox 5.52, 0.75, x, 19.43, '', chave[22, 3], { :size => 7, :border => 0, :style => :bold }
+          @pdf.ibox 5.52, 0.75, x, y, '', chave[22, 3], { :size => 7, :border => 0, :style => :bold }
           x = x + 1.00
-          @pdf.ibox 5.52, 1.75, x, 19.43, '', chave[25, 9].gsub(/^[0]+/, ''), { :size => 7, :border => 0, :style => :bold }
+          @pdf.ibox 5.52, 1.75, x, y, '', chave[25, 9].gsub(/^[0]+/, ''), { :size => 7, :border => 0, :style => :bold }
           x = x + 2.00
         end
       }

--- a/lib/ruby_danfe/danfe_generator.rb
+++ b/lib/ruby_danfe/danfe_generator.rb
@@ -276,7 +276,6 @@ module RubyDanfe
             13 => 0.86.cm
           },
           :cell_style => {:padding => 2, :border_width => 0} do |table|
-            @pdf.dash(5);
             table.column(6..13).style(:align => :right)
             table.column(0..13).border_width = 1
             table.column(0..13).borders = [:bottom]

--- a/lib/ruby_danfe/danfe_generator.rb
+++ b/lib/ruby_danfe/danfe_generator.rb
@@ -240,23 +240,6 @@ module RubyDanfe
         end
 
         info_adicional += "\nOUTRAS INFORMAÇÕES: "
-
-        if @xml['infAdic/infCpl'] == ""
-          inf_ad_fisco_y = y + 0.50
-        else
-          inf_ad_fisco_y = y + 0.100
-        end
-
-        @pdf.ibox 2.07, 12.93, 0.25, inf_ad_fisco_y, '', @xml['infAdic/infAdFisco'], {:size => 5, :valign => :top, :border => 0}
-
-      else
-        if @xml['infAdic/infCpl'] == ""
-          inf_ad_fisco_y = 26.60
-        else
-          inf_ad_fisco_y = 27.33
-        end
-
-        @pdf.ibox 3.07, 12.93, 0.25, inf_ad_fisco_y, "", @xml['infAdic/infAdFisco'], {:size => 6, :valign => :top, :border => 0}
       end
 
       info_adicional += @xml['infAdic/infCpl']
@@ -269,6 +252,10 @@ module RubyDanfe
           "Municipio: " + @xml['entrega/xMun'] + " " +
           "UF: " + @xml['entrega/UF'] + " " +
           "País: Brasil"
+      end
+      
+      if @xml['infAdic/infAdFisco'] != ""
+        info_adicional += "\n#{@xml['infAdic/infAdFisco']}"
       end
 
       @pdf.bounding_box [(0.33).cm, Helper.invert(26.78.cm)], height: 2.7.cm, width: 12.7.cm do

--- a/lib/ruby_danfe/descricao.rb
+++ b/lib/ruby_danfe/descricao.rb
@@ -8,21 +8,12 @@ module RubyDanfe
       descricao = "#{det.css('prod/xProd').text}"
 
       if need_infAdProd(det)
-        descricao += LINEBREAK
         descricao += det.css('infAdProd').text
       end
 
       if need_fci(det)
         descricao += LINEBREAK
         descricao += "FCI: #{det.css('prod/nFCI').text}"
-      end
-
-      if need_st(det)
-        descricao += LINEBREAK
-        descricao += "ST: MVA: #{det.css('ICMS/*/pMVAST').text}% "
-        descricao += "* Alíq: #{det.css('ICMS/*/pICMSST').text}% "
-        descricao += "* BC: #{det.css('ICMS/*/vBCST').text} "
-        descricao += "* Vlr: #{det.css('ICMS/*/vICMSST').text}"
       end
 
       descricao
@@ -35,10 +26,6 @@ module RubyDanfe
 
     def self.need_fci(det)
       !det.css('prod/nFCI').text.empty?
-    end
-
-    def self.need_st(det)
-      det.css('ICMS/*/vBCST').text.to_i > 0
     end
   end
 end

--- a/lib/ruby_danfe/document.rb
+++ b/lib/ruby_danfe/document.rb
@@ -1,14 +1,16 @@
 module RubyDanfe
   class Document
-    def initialize
-      @document = Prawn::Document.new(
+    def initialize(opts = {})
+      default_opts = {
         :page_size => 'A4',
         :page_layout => :portrait,
         :left_margin => 0,
         :right_margin => 0,
         :top_margin => 0,
         :botton_margin => 0
-      )
+      }
+
+      @document = Prawn::Document.new(default_opts.merge(opts))
 
       @document.font "Times-Roman"
     end
@@ -29,8 +31,8 @@ module RubyDanfe
       Barby::Code128C.new(info).annotate_pdf(self, :x => x.cm, :y => Helper.invert(y.cm), :width => w.cm, :height => h.cm) if info != ''
     end
 
-    def iqrcode(h, w, x, y, info)
-      Barby::QrCode.new(info, :level => :q).annotate_pdf(self, :x => x.cm, :y => Helper.invert(y.cm), :width => w.cm, :height => h.cm) if info != ''
+    def iqrcode(x, y, info, size = nil)
+      Barby::QrCode.new(info, :level => :q, :size => size).annotate_pdf(self, :x => x.cm, :y => Helper.invert(y.cm)) if info != ''
     end
 
     def irectangle(h, w, x, y)

--- a/lib/ruby_danfe/helper.rb
+++ b/lib/ruby_danfe/helper.rb
@@ -10,6 +10,16 @@ module RubyDanfe
         number
     end
 
+    def self.numerify_default_zero(number, decimals = 2)
+      number = number.tr("\n","").delete(" ")
+      return "0,00" if !number || number == ""
+      int, frac = ("%.#{decimals}f" % number).split(".")
+      int.gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1\.")
+      int + "," + frac
+      rescue
+        number
+    end
+
     def self.invert(y)
       28.7.cm - y
     end

--- a/lib/ruby_danfe/railtie.rb
+++ b/lib/ruby_danfe/railtie.rb
@@ -2,6 +2,7 @@ require "prawn"
 require "prawn/measurement_extensions"
 require "barby"
 require "barby/barcode/code_128"
+require 'barby/barcode/qr_code'
 require "barby/outputter/prawn_outputter"
 require "nokogiri"
 require 'ostruct'
@@ -15,6 +16,7 @@ require_relative 'document.rb'
 require_relative 'version.rb'
 require_relative 'dacte_generator.rb'
 require_relative 'danfe_generator.rb'
+require_relative 'danfe_nfce_generator.rb'
 require_relative 'xml.rb'
 require_relative 'descricao.rb'
 require_relative 'ruby_danfe.rb'

--- a/lib/ruby_danfe/railtie.rb
+++ b/lib/ruby_danfe/railtie.rb
@@ -7,6 +7,8 @@ require "barby/outputter/prawn_outputter"
 require "nokogiri"
 require 'ostruct'
 require 'yaml'
+require 'date'
+require 'time'
 
 require_relative '../ruby_danfe.rb'
 require_relative 'options.rb'

--- a/lib/ruby_danfe/ruby_danfe.rb
+++ b/lib/ruby_danfe/ruby_danfe.rb
@@ -35,15 +35,14 @@ module RubyDanfe
 
       xml = XML.new(xml_string)
 
-      if type == :danfe
-        generator = DanfeGenerator.new(xml)
-      elsif type == :danfe_nfce
-        generator = DanfeNfceGenerator.new(xml)
-      else
-        generator = DacteGenerator.new(xml)
-      end
+      generator =
+        case type
+          when :danfe then DanfeGenerator.new(xml)
+          when :danfe_nfce then DanfeNfceGenerator.new(xml)
+          when :dacte then DacteGenerator.new(xml)
+          else raise "unknown type #{type}"
+        end
 
-      pdf = generator.generatePDF
-      pdf
+      generator.generatePDF
     end
 end

--- a/lib/ruby_danfe/xml.rb
+++ b/lib/ruby_danfe/xml.rb
@@ -47,6 +47,21 @@ module RubyDanfe
       result
     end
 
+    def inject(ns, tag, acc, &block)
+      # Tenta primeiro com uso de namespace
+      begin
+        @xml.xpath("//#{ns}:#{tag}").each do |det|
+          acc = yield(acc, det)
+        end
+      rescue
+        # Caso dê erro, tenta sem
+        @xml.xpath("//#{tag}").each do |det|
+          acc = yield(acc, det)
+        end
+      end
+      acc
+    end
+
     def attrib(node, attrib)
       begin
         return @xml.css(node).attr(attrib).text

--- a/ruby_danfe.gemspec
+++ b/ruby_danfe.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogiri", "~> 1.6.3.1"
   spec.add_dependency "prawn", '~> 1.0.0'
+  spec.add_dependency "rqrcode"
   spec.add_dependency "barby"
   spec.add_dependency "rake"
 

--- a/test/generate.rb
+++ b/test/generate.rb
@@ -1,8 +1,10 @@
 require "../lib/ruby_danfe"
 
 if ARGV.size == 0
-  puts "Usage: generate.rb <filename>"
+  puts "Usage: generate.rb <filename> <type>"
   exit(1)
 end
 
-RubyDanfe.generate("#{ARGV[0]}.pdf", ARGV[0])
+type = (ARGV[1] || "danfe").to_sym
+
+RubyDanfe.generate("#{ARGV[0]}.pdf", ARGV[0], type)


### PR DESCRIPTION
Fixes #32 

Como não possuo as URLs de consulta de todos os estados, corrigi apenas a de RO. Para os demais deixei a mesma URL do QR code que já estavam no arquivo.

A flexão das URLs de QR code por homologação/produção também foi removida, pois estava incorreta.