### PR TITLE
adiciona aos outras modalidades de frete

### DIFF
--- a/lib/ruby_danfe/danfe_generator.rb
+++ b/lib/ruby_danfe/danfe_generator.rb
@@ -130,7 +130,7 @@ module RubyDanfe
       @pdf.ititle 0.42, 10.00, 0.25, 14.48, "TRANSPORTADOR / VOLUMES TRANSPORTADOS"
 
       @pdf.ibox 0.85, 9.02, 0.25, 14.90, "RAZÃO SOCIAL", @xml['transporta/xNome']
-      @pdf.ibox 0.85, 2.79, 9.27, 14.90, "FRETE POR CONTA", @xml['transp/modFrete'] == '0' ? ' 0 - EMITENTE' : '1 - DEST.'
+      @pdf.ibox 0.85, 2.79, 9.27, 14.90, "FRETE POR CONTA", descricao_modalidade_frete(@xml['transp/modFrete'])
       @pdf.ibox 0.85, 1.78, 12.06, 14.90, "CODIGO ANTT", @xml['veicTransp/RNTC']
       @pdf.ibox 0.85, 2.29, 13.84, 14.90, "PLACA DO VEÍCULO", @xml['veicTransp/placa']
       @pdf.ibox 0.85, 0.76, 16.13, 14.90, "UF", @xml['veicTransp/UF']
@@ -281,6 +281,19 @@ module RubyDanfe
             table.column(0..13).border_width = 1
             table.column(0..13).borders = [:bottom]
           end
+      end
+    end
+
+    def descricao_modalidade_frete(modalidade)
+      case modalidade
+      when '1'
+        "1 - Por conta do destinatário/remetente"
+      when '2'
+        "2 - Por conta de terceiros"
+      when '9'
+        "9 - Sem frete"
+      else
+        "0 - Por conta do emitente"
       end
     end
   end

--- a/ruby_danfe.gemspec
+++ b/ruby_danfe.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri", ">= 1.6"
-  spec.add_dependency "prawn", '>= 1.0'
+  spec.add_dependency "prawn", '~> 1.0.0'
   spec.add_dependency "barby"
   spec.add_dependency "rake"
 


### PR DESCRIPTION
Ao gerar a DANFE com a modalidade de frete do tipo 9 (Sem Frete), mostrava a modalidade 1. Adicionei as 4 opções de modalidade de frete disponíveis na NFe  