### PR TITLE
Atualiza o gemspec

### DIFF
--- a/ruby_danfe.gemspec
+++ b/ruby_danfe.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "prawn-table", "~> 0.2"
   spec.add_dependency "barby", "~> 0.5"
   spec.add_dependency "rqrcode", "~> 0.10"
-  spec.add_dependency "rake", "~> 10.0"
+  spec.add_dependency "rake"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/ruby_danfe.gemspec
+++ b/ruby_danfe.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "nokogiri", "~> 1.7.0.1"
-  spec.add_dependency "prawn", '~> 1.2.1'
-  spec.add_dependency 'prawn-table', '~> 0.1.0'
-  spec.add_dependency "barby"
-  spec.add_dependency "rqrcode"
-  spec.add_dependency "rake"
+  spec.add_dependency "nokogiri", "~> 1.8"
+  spec.add_dependency "prawn", "~> 1.2"
+  spec.add_dependency "prawn-table", "~> 0.2"
+  spec.add_dependency "barby", "~> 0.5"
+  spec.add_dependency "rqrcode", "~> 0.10"
+  spec.add_dependency "rake", "~> 10.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Da maneira que o gemspec está hoje, é inviável atualizar as gems dos projetos que usam esta. No projeto que usamos ela, por exemplo, não conseguimos atualizar o Nokogiri(devido ao modo que o *pessimistic version* foi aplicado). Além disso, tivemos problemas ao utilizar a gem pois dava o erro ```
NoMethodError: undefined method `table' for #<Prawn::Document:0x00007f9476aa94b8>
```, e para corrigi-lo tivemos que fixar a versão 0.2.2 da gem `prawn-table`(versão que corrigia este bug).

Este PR deixa a gem menos restritiva em relação às versões das dependências.